### PR TITLE
Adjust @sanity/icons peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react": "^18",
     "sanity": "^3",
     "@sanity/ui": "^1 || ^2.0.0-beta",
-    "@sanity/icons": "^2"
+    "@sanity/icons": ">= 2"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
The current bersion of @sanity/icons is 3.x, so pinning to 2.x will fail. This sets to >= 2.x, presuming there are not breaking changes.